### PR TITLE
Representation comparison: Sort results by validation accuracy, save results as CSV

### DIFF
--- a/representation_experiment.py
+++ b/representation_experiment.py
@@ -76,7 +76,7 @@ def make_classifier():
     """
     make_classifier returns the classifier used to compare the representations.
     """
-    return sklearn.ensemble.AdaBoostClassifier()
+    return sklearn.ensemble.RandomForestClassifier(max_depth=3)
 
 
 def hyperparameter_grid(choices: dict) -> dict:


### PR DESCRIPTION
Sort the results by a predefined metric from sklearn.metrics.classification_report (by default the validation accuracy), calculate its mean and standard deviation across cross-validation folds, and save all of the results as CSV instead of JSON.